### PR TITLE
feat(resume): convert to full-page scroll with full-bleed sections + centered inner containers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-// src/App.tsx
 import { Outlet, NavLink, useLocation } from 'react-router-dom'
 
 const Nav = () => (
@@ -9,7 +8,7 @@ const Nav = () => (
       </NavLink>
 
       <ul className="flex items-center gap-6 text-sm">
-        <li><NavLink to="resume"   className={({ isActive }) => (isActive ? 'font-semibold' : '')}>Resume</NavLink></li>
+        <li><NavLink to="resume"    className={({ isActive }) => (isActive ? 'font-semibold' : '')}>Resume</NavLink></li>
         <li><NavLink to="proofmint" className={({ isActive }) => (isActive ? 'font-semibold' : '')}>Proofmint</NavLink></li>
         <li><NavLink to="projects"  className={({ isActive }) => (isActive ? 'font-semibold' : '')}>Projects</NavLink></li>
         <li><NavLink to="about"     className={({ isActive }) => (isActive ? 'font-semibold' : '')}>About</NavLink></li>
@@ -34,8 +33,8 @@ export default function App() {
   return (
     <div className="min-h-screen flex flex-col">
       <Nav />
-      {/* Drop container on resume so hero can go full-bleed */}
-      <main className={`${isResume ? '' : 'container-nwc'} flex-1 py-10`}>
+      {/* No container or extra padding on Resume */}
+      <main className={`${isResume ? '' : 'container-nwc py-10'} flex-1`}>
         <Outlet />
       </main>
       <Footer />

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -1,0 +1,123 @@
+import { Link } from "react-router-dom";
+import "../styles/resume.css";
+
+export default function Resume() {
+  return (
+    <div className="resume">
+      <header className="header">
+        <div className="hero-inner">
+          <div className="header-links flex-start">
+            <div className="profile-container">
+              <img className="profile" src="/img/profile.jpg" alt="Profile" />
+              <img className="ring" src="/img/Ring.svg" alt="Ring Border" />
+            </div>
+
+            <ul className="flex-list list-items-circle">
+              <li><a href="https://www.linkedin.com/"><i className="fab fa-linkedin" /></a></li>
+              <li><a href="https://github.com/CryptoMachineGene"><i className="fab fa-github" /></a></li>
+              <li><a href="https://twitter.com/CryptoMachineG"><i className="fab fa-twitter" /></a></li>
+            </ul>
+          </div>
+
+          <h1>
+            Hi, I’m Eugene McGrath
+            <br />
+            Blockchain Developer
+          </h1>
+
+          <ul className="contact-details flex-list">
+            <li>United States</li>
+            <hr />
+            <li><a href="mailto:gene@newworldcryptos.io">gene@newworldcryptos.io</a></li>
+          </ul>
+        </div>
+      </header>
+
+      <main>
+        {/* ABOUT */}
+        <section className="section about">
+          <div className="section-inner">
+            <h2>
+              I build and audit decentralized applications focused on financial sovereignty,
+              transparency, and privacy — blending blockchain engineering with user-first design.
+            </h2>
+            <ul className="achievements">
+              <li>🏆 Dapp University Blockchain Developer Mentorship</li>
+              <li>🏆 EatTheBlocks Certified Web3 Developer</li>
+            </ul>
+          </div>
+        </section>
+
+        {/* PROJECTS */}
+        <section className="section projects">
+          <div className="section-inner">
+            <div className="flex-between">
+              <h2>Selected Projects</h2>
+              <a href="https://github.com/CryptoMachineGene" className="projects-link flex-between">
+                See all works <img src="/img/ArrowUpRight.svg" alt="Arrow" style={{ marginLeft: 8, opacity: 0.7 }} />
+              </a>
+            </div>
+
+            <div className="cards flex-center">
+              <div className="card">
+                <img src="/img/projects/project_1.png" alt="Proofmint dApp" />
+                <h3 className="card-title">Proofmint</h3>
+                <p className="card-description">
+                  Full-stack token crowdsale + NFT receipt dApp (Hardhat, Solidity, React).
+                </p>
+                <div className="card-buttons">
+                  <a href="https://cryptomachinegene.github.io/proofmint-project/" className="card-button--site">Site</a>
+                  <a href="https://github.com/CryptoMachineGene/proofmint-project" className="card-button--code">Code</a>
+                </div>
+              </div>
+
+              <div className="card">
+                <img src="/img/projects/project_2.png" alt="Sakura Token" />
+                <h3 className="card-title">Sakura Token (SKR)</h3>
+                <p className="card-description">
+                  Custom ERC-20 token with delegated transfer tests (Solidity + Hardhat).
+                </p>
+                <div className="card-buttons">
+                  <a href="#" className="card-button--site">Site</a>
+                  <a href="https://github.com/CryptoMachineGene/sakura-contract" className="card-button--code">Code</a>
+                </div>
+              </div>
+
+              <div className="card">
+                <img src="/img/projects/project_3.png" alt="Solana Hello World" />
+                <h3 className="card-title">Solana Hello World</h3>
+                <p className="card-description">
+                  Anchor + Rust Hello World smart contract verified on localnet.
+                </p>
+                <div className="card-buttons">
+                  <a href="#" className="card-button--site">Site</a>
+                  <a href="https://github.com/CryptoMachineGene/solana-hello-world" className="card-button--code">Code</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* SKILLS */}
+        <section className="section skills">
+          <div className="section-inner">
+            <h2>Tech Stack</h2>
+            <div className="skill-cards flex-center">
+              <div className="skill-card flex-center"><i className="fab fa-react" /></div>
+              <div className="skill-card flex-center"><i className="fab fa-node-js" /></div>
+              <div className="skill-card flex-center"><i className="fab fa-ethereum" /></div>
+              <div className="skill-card flex-center"><i className="fab fa-js-square" /></div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer className="footer flex-center">
+        <p><small>© {new Date().getFullYear()} Eugene McGrath · Built with React + Vite</small></p>
+        <div style={{ marginTop: 16 }}>
+          <Link to="/">← Back to Home</Link>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/styles/resume.css
+++ b/src/styles/resume.css
@@ -20,12 +20,12 @@
   overflow-x: hidden;
 }
 
-/* Full-bleed hero that escapes any parent width constraints */
+//* Full-bleed HERO */
 .resume .header {
   min-height: 100vh;
   width: 100vw;
   margin-left: 50%;
-  transform: translateX(-50%);       /* center the full-width block */
+  transform: translateX(-50%);
   padding-block: clamp(32px, 6vw, 96px);
   padding-inline: clamp(32px, 6vw, 96px);
   background-image: url('/img/Background.png');
@@ -34,12 +34,27 @@
   color: var(--black);
 }
 
-/* Keep inner content nicely centered and capped */
-.resume .hero-inner {
+/* Full-bleed SECTIONS */
+.resume .section {
+  width: 100vw;
+  margin-left: 50%;
+  transform: translateX(-50%);
+  padding-block: clamp(48px, 6vw, 110px);
+  padding-inline: clamp(32px, 6vw, 96px);
+  min-height: unset; /* drop fixed 850px so content dictates height */
+}
+
+/* Shared inner container for hero + sections */
+.resume .hero-inner,
+.resume .section-inner {
   width: min(1100px, 100%);
   margin: 0 auto;
 }
 
+/* Darker base for content sections (Vector pattern sits on top where applied) */
+.resume .section:not(.about):not(.skills) {
+  background-color: #060003;
+}
 
 /* TYPOGRAPHY */
 .resume h1 { font-weight: 400; font-size: var(--font-96); line-height: 116px; }


### PR DESCRIPTION
### Summary
Refactors the Resume page into a full-page, scrollable layout that acts as the main portfolio landing. 
Each section (hero, about, projects, skills) now spans the full viewport width, matching modern developer portfolio standards.

### Changes
- Dropped `.container-nwc` wrapper for the Resume route in `App.tsx` so sections can expand full width.
- Updated `resume.css` to use full-bleed hero and section styling (`width: 100vw; transform: translateX(-50%)`).
- Added `.section-inner` wrapper for centered text and grid alignment across all Resume sections.
- Design now matches the scroll-through layout shown in the visual references (hero → about → projects → skills).

### Result
Visiting `/` or `/resume` now renders the Resume as a seamless, full-width scrolling portfolio homepage 
with a gradient hero, vector section transitions, and responsive layout throughout.
